### PR TITLE
Fix old-style license check

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -3,4 +3,4 @@
 
 docs
 *.pyc
-.stylefilter
+.reuse/dep5


### PR DESCRIPTION
It was complaining about the new dep5 file, which doesn't contain
a license of its own.
