### PR TITLE
Fix tutorial tests

### DIFF
--- a/tools/expect.py
+++ b/tools/expect.py
@@ -57,7 +57,7 @@ def main():
         completion_text = args.text
     build_dir = os.path.dirname(__file__)
     result = simulate_with_checks(build_dir, completion_text)
-    if result is 0:
+    if result == 0:
         print("Success!")
     elif result <= len(FAILURE_TEXTS):
         print("Failure! {0}".format(FAILURE_TEXTS[result - 1]))


### PR DESCRIPTION
The main non-trivial commit is there to fix a test in the non-passing build of sel4-tutorials in CI. The stop-gap measure is to get around an issue with regards to this commit in camkes-tool https://github.com/seL4/camkes-tool/commit/4deed6e61dc724bca094046b726776e9643e921a that I haven't been able to figure out why it's causing an issue with the hello-camkes-1 and hello-camkes-2 unit tests.