### PR TITLE
tutorials: Update VM tutorials to use arch func

### DIFF
--- a/tutorials/camkes-vm-crossvm/camkes-vm-crossvm.md
+++ b/tutorials/camkes-vm-crossvm/camkes-vm-crossvm.md
@@ -557,8 +557,8 @@ endif()
 /*? include_task_type_append([("crossvm", "vm-cmake-init0")]) ?*/
 /*? include_task_type_append([("crossvm", "vm-cmake-printserver")]) ?*/
 # Get Default Linux VM files
-GetDefaultLinuxKernelFile(default_kernel_file)
-GetDefaultLinuxRootfsFile(default_rootfs_file)
+GetArchDefaultLinuxKernelFile("32" default_kernel_file)
+GetArchDefaultLinuxRootfsFile("32" default_rootfs_file)
 
 # Decompress Linux Kernel image and add to file server
 DecompressLinuxKernel(extract_linux_kernel decompressed_kernel ${default_kernel_file})

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -182,7 +182,7 @@ The file `projects/camkes/vm/camkes_vm_helpers.cmake` provides helper functions 
 including  `DeclareCAmkESVM(Init0)`, which is used to define the `Init0` VM component.
 Each Init component requires a corresponding `DeclareCAmkESVM` function.
 
-`GetArchDefaultLinuxKernelFile` (defined in `projects/camkes/vm-linux/vm-linux-helpers.cmake`) 
+`GetArchDefaultLinuxKernelFile` (defined in `projects/camkes/vm-linux/vm-linux-helpers.cmake`)
 is a helper function that retrieves the location of an architectural specific vm image provided
 in the `projects/vm-linux` folder, which contains some tools for building new linux kernel
 and root filesystem images, as well as the images that these tools

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -421,8 +421,8 @@ GetDefaultLinuxMinor(linux_minor)
 GetDefaultLinuxMd5(linux_md5)
 # Download and Configure our Linux sources
 DownloadLinux(${linux_major} ${linux_minor} ${linux_md5} vm_linux_extract_dir download_vm_linux)
-set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/config")
-set(linux_symvers "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/Module.symvers")
+set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/32/config")
+set(linux_symvers "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/32/Module.symvers")
 ConfigureLinux(${vm_linux_extract_dir} ${linux_config} ${linux_symvers} configure_vm_linux
     DEPENDS download_vm_linux
 )

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -157,8 +157,8 @@ include(${CAMKES_VM_LINUX_HELPERS_PATH})
 DeclareCAmkESVM(Init0)
 
 # Get Default Linux VM files
-GetDefaultLinuxKernelFile(default_kernel_file)
-GetDefaultLinuxRootfsFile(default_rootfs_file)
+GetArchDefaultLinuxKernelFile("32" default_kernel_file)
+GetArchDefaultLinuxRootfsFile("32" default_rootfs_file)
 
 # Decompress Linux Kernel image and add to file server
 DecompressLinuxKernel(extract_linux_kernel decompressed_kernel ${default_kernel_file})
@@ -182,8 +182,8 @@ The file `projects/camkes/vm/camkes_vm_helpers.cmake` provides helper functions 
 including  `DeclareCAmkESVM(Init0)`, which is used to define the `Init0` VM component.
 Each Init component requires a corresponding `DeclareCAmkESVM` function.
 
-`GetDefaultLinuxKernelFile` (defined in `projects/camkes/vm-linux/vm-linux-helpers.cmake`) 
-is a helper function that retrieves the location of the vm images provided
+`GetArchDefaultLinuxKernelFile` (defined in `projects/camkes/vm-linux/vm-linux-helpers.cmake`) 
+is a helper function that retrieves the location of an architectural specific vm image provided
 in the `projects/vm-linux` folder, which contains some tools for building new linux kernel
 and root filesystem images, as well as the images that these tools
 produce. A fresh checkout of this project will contain some pre-built


### PR DESCRIPTION
The VM tutorials now use the new CMake helper functions to fetch an
architecturally specific image. These tutorials require the 32-bit
version of the guest Linux images.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>