### PR TITLE
Add initial kernel module tutorial

### DIFF
--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -5,19 +5,20 @@
 -->
 # Cross-Compiling Kernel Modules for use with seL4's Linux VM using qemu-arm-virt
 
-This is a procedure to prepare a camkes app for cross-compiling linux kernel modules for use in virtualization.
+This is a procedure to prepare a CAmkES app for cross-compiling linux kernel modules for use in virtualization.
 
-See the "module_minimal" app for a ready-to-build camkes application.
+See the "module_minimal" app for a ready-to-build CAmkES application.
 
-1. download linux kernel repo
+1. Download linux kernel repository.
 ```
 git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 cd linux-stable
 git checkout linux-4.9.y
 git fetch
 ```
+In this step we gather the linux kernel source for compilation later. We require the linux source in order to compile kernel modules against it. If we have a version mismatch, or even a configuration mismatch at compile-time, our kernel modules will not be considered "valid" at run-time. We choose to use linux-4.9.y (the latest version of 4.9) because seL4 supports a build-configuration for this version of linux, which we will use in the next step.
 
-2. grab the config from seL4
+2. Borrow the linux-kernel configuration from seL4.
 ```
 make clean
 rm Module.symvers
@@ -25,23 +26,27 @@ rm .config
 rm .config.old
 cp .../projects/camkes-vm-images/qemu-arm-virt/linux_configs/config ./.config
 ```
+In this step we copy the particular configuration used to compile the linux kernel for seL4. There are myriad configuration options available, so this is extremely convenient.
 
-3. prepare kernel for cross-compilation, choosing default config options always
+3. Prepare kernel for cross-compilation, choosing default config options always.
 ```
 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare
 ```
+In this step we perform the "first half" of the kernel compilation. This configures our build system using the configuration we borrowed from seL4 in the last step. There are a few options apparently not disambiguated by the configuration we borrowed, so we have to manually accept a few options. The default choices for these options are acceptable, so at this step I literally press my "Enter" button three times fast.
 
-4. build linux kernel (where X is the number of tasks you want to create)
+4. Build linux kernel (where X is the number of tasks you want to create).
 ```
 make -jX ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 ```
+In this step we perform the "second half" of compilation. Namely, we actually compile the kernel, which might take hours depending on your machine. If you have the processor cores to spare, I highly recommend setting X in this invocation to as high a number as your machine can muster. The linux kernel compilation process appears very highly parallelized, so when I set X to be `$(nproc)`, which is "the number of available processing units," I can garner a speedup of nearly 6. In a concrete sense, my machine takes about 90 minutes in the single-core case, and only about 15 minutes in the `$(nproc)`-core case.
 
-5. add the newly built kernel to the camkes build path
+5. Add the newly built kernel to the CAmkES build path.
 ```
 cp arch/arm64/boot/Image [...]/projects/camkes-vm-images/qemu-arm-virt/newLinux
 ```
+In this step we place our newly built kernel into a natural and convenient place in the CAmkES filepath. This is so we can access it easily in the next step.
 
-6. edit your cmakelists.txt to use the new kernel by replacing this line:
+6. Edit your CAmkES application's root cmakelists.txt to use the new kernel by replacing this line:
 ```
 AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/linux")
 ```
@@ -49,14 +54,17 @@ with this line:
 ```
 AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/newLinux")
 ```
-7. from the kernel build directory, add the config and symbols files to the camkes build path
+In this step we redirect the CMake build system away from using the provided linux kernel and towards using our newly built kernel. That is, seL4 comes pre-packaged with a Linux kernel ready-to-use, but this ready-to-use kernel is not sufficient for our kernel-module purposes. For this reason, we must ensure our application uses our newly built kernel instead.
+
+7. From the kernel build directory, add the config and symbols files to the CAmkES build path.
 ```
 mkdir -p [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64
 cp .config [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64/config
 cp Module.symvers [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64/Module.symvers
 ```
+In this step, we add information regarding the compilation of our kernel to the CAmkES filepath. We are required to do this in order for the kernel-module build to succeed in a later step. Namely, our kernel modules must know two things in order to be compatible with the kernel: how the kernel was built and what symbols its build process exported.
 
-8. update CMakeLists.txt to build the module using the new kernel sources
+8. Update CMakeLists.txt to build the module using the new kernel sources.
 ```
 # Setup and Configure Linux Sources
 set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/4.9.y/64/config")
@@ -67,7 +75,7 @@ set(linux_dir "/host/linux-stable")
 
 ConfigureLinux(${linux_dir} ${linux_config} ${linux_symvers} configure_vm_linux)
 
-# Add the external hello module project
+# Setup our kernel module for compilation as part of the standard CAmkES-app build process.
 ExternalProject_Add(hello-module
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/hello-module
@@ -82,15 +90,20 @@ ExternalProject_Add(hello-module
         -DLINUX_KERNEL_DIR=${linux_dir}
         -DMODULE_HELPERS_FILE=${CAMKES_VM_LINUX_DIR}/linux-module-helpers.cmake
 )
-# Add our module binary to the overlay
-AddExternalProjFilesToOverlay(hello-module
-${CMAKE_CURRENT_BINARY_DIR}/hello-module vm-overlay "lib/modules/4.9.275/kernel/drivers/vmm"
-    FILES hello.ko)
 
+# Add our module binary to the overlay
+AddExternalProjFilesToOverlay(
+    hello-module
+    ${CMAKE_CURRENT_BINARY_DIR}/hello-module
+    vm-overlay
+    "lib/modules/4.9.275/kernel/drivers/vmm"
+    FILES
+    hello.ko)
+
+# Add an init script which should load our module at boot-time
 AddFileToOverlayDir("init" ${CMAKE_CURRENT_SOURCE_DIR}/init "/etc/init.d" vm-overlay)
 
-# Generate overlayed rootfs
-
+# Add our overlay to the root filesystem used by Linux
 AddOverlayDirToRootfs(
     vm-overlay
     ${rootfs_file}
@@ -100,11 +113,11 @@ AddOverlayDirToRootfs(
     rootfs_target
     GZIP
 )
-
 AddToFileServer("linux-initrd" ${output_overlayed_rootfs_location} DEPENDS rootfs_target)
 ```
+In this step we equip CMake to handle our kernel module compilation and addition to the Linux file system.
 
-9. Ensure the module Makefile is configured for cross compilation
+9. Ensure the kernel-module's Makefile is configured for cross compilation.
 ```
 obj-m += hello.o
 
@@ -116,4 +129,4 @@ clean:
 
 ```
 
-10. Build your project like normal.
+10. Build your CAmkES application like normal.

--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -5,7 +5,11 @@
 -->
 # Cross-Compiling Kernel Modules for use with seL4's Linux VM using qemu-arm-virt
 
-See [the code](https://github.com/NeisesResearch/kernel_module_workstation) for the automation of this procedure. Running the setup script there should give you a camkes application, ready to build and simulate, which demonstrates the cross-compilation of a trivial kernel module for use in the linux kernel virtualized in the camkes-arm-vm. The procedure here outlines the specific steps necessary for module cross-compilation.
+This is a procedure to prepare a camkes app for cross-compiling linux kernel modules for use in virtualization.
+
+See [the camkes app](https://github.com/seL4/sel4-tutorials/tree/master/tutorials/camkes-vm-kernel-module/module_minimal) for a ready-to-build project.
+
+See [an automation](https://github.com/NeisesResearch/kernel_module_workstation) of this procedure. Cloning that repo and running the setup script there should give you a camkes application, ready to build and simulate, which demonstrates the cross-compilation of a trivial kernel module.
 
 1. download linux kernel repo
 ```
@@ -113,4 +117,5 @@ clean:
 	make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -C $(KHEAD) M=$(PWD) clean
 
 ```
-10. Build your [project](https://github.com/NeisesResearch/kernel_module_workstation/tree/main/module_minimal) like normal.
+
+10. Build your [project](https://github.com/seL4/sel4-tutorials/tree/master/tutorials/camkes-vm-kernel-module/module_minimal) like normal.

--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -1,3 +1,8 @@
+<!--
+  Copyright 2021 Michael Neises
+
+  SPDX-License-Identifier: BSD-2-Clause
+-->
 # Cross-Compiling Kernel Modules for use with seL4's Linux VM using qemu-arm-virt
 
 See [the code](https://github.com/NeisesResearch/kernel_module_workstation) for the automation of this procedure. Running the setup script there should give you a camkes application, ready to build and simulate, which demonstrates the cross-compilation of a trivial kernel module for use in the linux kernel virtualized in the camkes-arm-vm. The procedure here outlines the specific steps necessary for module cross-compilation.

--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -9,8 +9,6 @@ This is a procedure to prepare a camkes app for cross-compiling linux kernel mod
 
 See [the camkes app](https://github.com/seL4/sel4-tutorials/tree/master/tutorials/camkes-vm-kernel-module/module_minimal) for a ready-to-build project.
 
-See [an automation](https://github.com/NeisesResearch/kernel_module_workstation) of this procedure. Cloning that repo and running the setup script there should give you a camkes application, ready to build and simulate, which demonstrates the cross-compilation of a trivial kernel module.
-
 1. download linux kernel repo
 ```
 git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git

--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -1,0 +1,111 @@
+# Cross-Compiling Kernel Modules for use with seL4's Linux VM using qemu-arm-virt
+
+See [the code](https://github.com/NeisesResearch/kernel_module_workstation) for the automation of this procedure. Running the setup script there should give you a camkes application, ready to build and simulate, which demonstrates the cross-compilation of a trivial kernel module for use in the linux kernel virtualized in the camkes-arm-vm. The procedure here outlines the specific steps necessary for module cross-compilation.
+
+1. download linux kernel repo
+```
+git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+cd linux-stable
+git checkout linux-4.9.y
+git fetch
+```
+
+2. grab the config from seL4
+```
+make clean
+rm Module.symvers
+rm .config
+rm .config.old
+cp .../projects/camkes-vm-images/qemu-arm-virt/linux_configs/config ./.config
+```
+
+3. prepare kernel for cross-compilation, choosing default config options always
+```
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare
+```
+
+4. build linux kernel (where X is the number of tasks you want to create)
+```
+make -jX ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+```
+
+5. add the newly built kernel to the camkes build path
+```
+cp arch/arm64/boot/Image [...]/projects/camkes-vm-images/qemu-arm-virt/newLinux
+```
+
+6. edit your cmakelists.txt to use the new kernel by replacing this line:
+```
+AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/linux")
+```
+with this line:
+```
+AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/newLinux")
+```
+7. from the kernel build directory, add the config and symbols files to the camkes build path
+```
+mkdir -p [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64
+cp .config [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64/config
+cp Module.symvers [...]/projects/camkes-vm-linux/linux_configs/4.9.y/64/Module.symvers
+```
+
+8. update CMakeLists.txt to build the module using the new kernel sources
+```
+# Setup and Configure Linux Sources
+set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/4.9.y/64/config")
+set(linux_symvers "${CAMKES_VM_LINUX_DIR}/linux_configs/4.9.y/64/Module.symvers")
+
+# linux_dir should point to wherever you built the kernel
+set(linux_dir "/host/linux-stable")
+
+ConfigureLinux(${linux_dir} ${linux_config} ${linux_symvers} configure_vm_linux)
+
+# Add the external hello module project
+ExternalProject_Add(hello-module
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/hello-module
+    BUILD_ALWAYS ON
+    STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/hello-module-stamp
+    EXCLUDE_FROM_ALL
+    INSTALL_COMMAND ""
+    DEPENDS configure_vm_linux
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_TOOLCHAIN_FILE=${LINUX_64BIT_TOOLCHAIN}
+        -DLINUX_KERNEL_DIR=${linux_dir}
+        -DMODULE_HELPERS_FILE=${CAMKES_VM_LINUX_DIR}/linux-module-helpers.cmake
+)
+# Add our module binary to the overlay
+AddExternalProjFilesToOverlay(hello-module
+${CMAKE_CURRENT_BINARY_DIR}/hello-module vm-overlay "lib/modules/4.9.275/kernel/drivers/vmm"
+    FILES hello.ko)
+
+AddFileToOverlayDir("init" ${CMAKE_CURRENT_SOURCE_DIR}/init "/etc/init.d" vm-overlay)
+
+# Generate overlayed rootfs
+
+AddOverlayDirToRootfs(
+    vm-overlay
+    ${rootfs_file}
+    "buildroot"
+    "rootfs_install"
+    output_overlayed_rootfs_location
+    rootfs_target
+    GZIP
+)
+
+AddToFileServer("linux-initrd" ${output_overlayed_rootfs_location} DEPENDS rootfs_target)
+```
+
+9. Ensure the module Makefile is configured for cross compilation
+```
+obj-m += hello.o
+
+all:
+	make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -C $(KHEAD) M=$(PWD) modules
+
+clean:
+	make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -C $(KHEAD) M=$(PWD) clean
+
+```
+10. Build your [project](https://github.com/NeisesResearch/kernel_module_workstation/tree/main/module_minimal) like normal.

--- a/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
+++ b/tutorials/camkes-vm-kernel-module/camkes-vm-kernel-module.md
@@ -7,7 +7,7 @@
 
 This is a procedure to prepare a camkes app for cross-compiling linux kernel modules for use in virtualization.
 
-See [the camkes app](https://github.com/seL4/sel4-tutorials/tree/master/tutorials/camkes-vm-kernel-module/module_minimal) for a ready-to-build project.
+See the "module_minimal" app for a ready-to-build camkes application.
 
 1. download linux kernel repo
 ```
@@ -116,4 +116,4 @@ clean:
 
 ```
 
-10. Build your [project](https://github.com/seL4/sel4-tutorials/tree/master/tutorials/camkes-vm-kernel-module/module_minimal) like normal.
+10. Build your project like normal.

--- a/tutorials/camkes-vm-kernel-module/module_minimal/CMakeLists.txt
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/CMakeLists.txt
@@ -1,0 +1,117 @@
+#
+# Copyright 2021 Michael Neises
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+cmake_minimum_required(VERSION 3.8.2)
+
+project(module-minimal C)
+
+include(${CAMKES_ARM_VM_HELPERS_PATH})
+
+# Create our CPP Flags based on ARM VM config variables
+find_package(camkes-vm-linux REQUIRED)
+include(${CAMKES_VM_LINUX_HELPERS_PATH})
+set(cpp_flags "-DKERNELARMPLATFORM_QEMU-ARM-VIRT")
+
+# Add our custom linux kernel
+AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/newLinux")
+
+# Grab the default rootfs
+set(rootfs_file "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/rootfs.cpio.gz")
+
+include(${CAMKES_VM_LINUX_SOURCE_HELPERS_PATH})
+include(${CAMKES_VM_LINUX_MODULE_HELPERS_PATH})
+include(ExternalProject)
+include(external-project-helpers)
+
+# Setup and configure linux sources
+set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/4.9.y/64/config")
+set(linux_symvers "${CAMKES_VM_LINUX_DIR}/linux_configs/4.9.y/64/Module.symvers")
+
+# Set the directory of our custom linux kernel
+set(linux_dir "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/linux-stable")
+
+# Add the external hello module project
+ExternalProject_Add(hello-module
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/hello-module
+    BUILD_ALWAYS ON
+    STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/hello-module-stamp
+    EXCLUDE_FROM_ALL
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_TOOLCHAIN_FILE=${LINUX_64BIT_TOOLCHAIN}
+        -DLINUX_KERNEL_DIR=${linux_dir}
+        -DMODULE_HELPERS_FILE=${CAMKES_VM_LINUX_DIR}/linux-module-helpers.cmake
+)
+
+# Add our module binary to the overlay
+# The number at this time happens to be 275.
+AddExternalProjFilesToOverlay(
+    hello-module
+    ${CMAKE_CURRENT_BINARY_DIR}/hello-module
+    vm-overlay
+    "lib/modules/4.9.275/kernel/drivers/vmm"
+    FILES
+    hello.ko
+)
+
+# Add our module's init script- just an insmod call
+AddFileToOverlayDir(
+    "init"
+    ${CMAKE_CURRENT_SOURCE_DIR}/init
+    "/etc/init.d"
+    vm-overlay
+)
+
+# Generate overlayed rootfs
+AddOverlayDirToRootfs(
+    vm-overlay
+    ${rootfs_file}
+    "buildroot"
+    "rootfs_install"
+    output_overlayed_rootfs_location
+    rootfs_target
+    GZIP
+)
+
+# Add the newly built rootfs
+AddToFileServer(
+    "linux-initrd"
+    ${output_overlayed_rootfs_location}
+    DEPENDS
+    rootfs_target
+)
+
+# Updated dtb based on initrd
+UpdateDtbFromInitrd(
+    "${CAMKES_VM_IMAGES_DIR}/qemu-arm-virt/linux-dtb"
+    ${rootfs_file}
+    "0x4d700000"
+    dtb_gen_target
+    output_dtb_location
+)
+AddToFileServer("linux-dtb" "${output_dtb_location}" DEPENDS dtb_gen_target)
+include(simulation)
+set(SIMULATION ON CACHE BOOL "Generate simulation script to run qemu with the proper arguments")
+if(SIMULATION)
+    GenerateSimulateScript()
+endif()
+
+AddCamkesCPPFlag(cpp_flags CONFIG_VARS VmEmmc2NoDMA VmVUSB Tk1DeviceFwd Tk1Insecure)
+
+DefineCAmkESVMFileServer()
+
+CAmkESAddImportPath(${KernelARMPlatform})
+
+# Declare root server
+DeclareCAmkESRootserver(
+    module_minimal.camkes
+    CPP_FLAGS
+    ${cpp_flags}
+    CPP_INCLUDES
+    ${CAMKES_VM_DIR}/components/VM_Arm
+)

--- a/tutorials/camkes-vm-kernel-module/module_minimal/module_minimal.camkes
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/module_minimal.camkes
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2021 Michael Neises
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <configurations/vm.h>
+
+import <std_connector.camkes>;
+import <global-connectors.camkes>;
+import <vm-connectors.camkes>;
+import <VM_Arm/VM.camkes>;
+import <devices.camkes>;
+
+assembly {
+    composition {
+        VM_GENERAL_COMPOSITION_DEF()
+        VM_COMPOSITION_DEF(0)
+        connection seL4VMDTBPassthrough vm_dtb(from vm0.dtb_self, to vm0.dtb);
+    }
+    configuration {
+        VM_GENERAL_CONFIGURATION_DEF()
+        VM_CONFIGURATION_DEF(0)
+
+        vm0.num_extra_frame_caps = 0;
+        vm0.extra_frame_map_address = 0;
+        vm0.cnode_size_bits = 23;
+        vm0.simple_untyped24_pool = 12;
+    }
+}

--- a/tutorials/camkes-vm-kernel-module/module_minimal/modules/CMakeLists.txt
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/modules/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright 2021 Michael Neises
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+cmake_minimum_required(VERSION 3.8.2)
+if(NOT MODULE_HELPERS_FILE)
+    message(FATAL_ERROR "MODULE_HELPERS_FILE is not defined")
+endif()
+include("${MODULE_HELPERS_FILE}")
+DefineLinuxModule(${CMAKE_CURRENT_LIST_DIR}/hello hello-module hello-target KERNEL_DIR ${LINUX_KERNEL_DIR})

--- a/tutorials/camkes-vm-kernel-module/module_minimal/modules/hello/Makefile
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/modules/hello/Makefile
@@ -1,0 +1,9 @@
+#  Copyright 2021 Michael Neises
+#
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+obj-m += hello.o
+all:
+	make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -C $(KHEAD) M=$(PWD) modules
+clean:
+	make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -C $(KHEAD) M=$(PWD) clean

--- a/tutorials/camkes-vm-kernel-module/module_minimal/modules/hello/hello.c
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/modules/hello/hello.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Michael Neises
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/fs.h>
+#include <asm/uaccess.h>
+#include <asm/kvm_para.h>
+#include <asm/io.h>
+
+static int __init hello_init(void)
+{
+    printk("\n==============================\n");
+    printk("Greetings");
+    printk("\n==============================\n");
+    return 0;
+}
+
+static void __exit hello_exit(void)
+{
+    printk("\n==============================\n");
+    printk("Bye-Bye");
+    printk("\n==============================\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);

--- a/tutorials/camkes-vm-kernel-module/module_minimal/qemu-arm-virt/devices.camkes
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/qemu-arm-virt/devices.camkes
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 Michael Neises
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <configurations/vm.h>
+
+#define VM_INITRD_MAX_SIZE 0x1900000 //25 MB
+#define VM_RAM_BASE 0x40000000
+#define VM_RAM_SIZE 0x20000000
+#define VM_RAM_OFFSET 0x00000000
+#define VM_DTB_ADDR 0x4F000000
+#define VM_INITRD_ADDR 0x4D700000
+
+assembly {
+	composition {}
+	configuration {
+
+        vm0.linux_address_config = {
+            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+            "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
+            "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
+            "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
+        };
+
+        vm0.linux_image_config = {
+            "linux_bootcmdline" : "",
+            "linux_stdout" : "/pl011@9000000",
+        };
+        vm0.num_vcpus = 2;
+
+        vm0.dtb = dtb([
+                        {"path": "/pl011@9000000"},
+                    ]);
+
+        vm0.untyped_mmios = [
+                    "0x8040000:12", // Interrupt Controller Virtual CPU interface (Virtual Machine view)
+                    "0x40000000:29", // Linux kernel memory regions
+                    ];
+	}
+}

--- a/tutorials/camkes-vm-kernel-module/module_minimal/settings.cmake
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/settings.cmake
@@ -1,0 +1,18 @@
+#
+# Copyright 2021 Michael Neises
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set(supported "qemu-arm-virt")
+if(NOT "${PLATFORM}" IN_LIST supported)
+    message(FATAL_ERROR "PLATFORM: ${PLATFORM} not supported.
+         Supported: ${supported}")
+endif()
+
+set(LibUSB OFF CACHE BOOL "" FORCE)
+
+# force cpu
+set(QEMU_MEMORY "2048")
+set(KernelArmCPU cortex-a53 CACHE STRING "" FORCE)
+set(VmInitRdFile ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Signed-off-by: Michael Neises <neisesmichael@gmail.com>

This merge would add a tutorial for building kernel modules for use with camkes-vm-linux. This tutorial differs from [this tutorial](https://docs.sel4.systems/Tutorials/camkes-vm-linux.html#adding-a-kernel-module) because this new procedure works in the case of simulation with qemu-arm-virt. This tutorial was motivated in part by the desire for rapid-prototyping, for which simulation is key.

This procedure has been tested to work using both Debian 10 and WSL2 on Windows 10.

This tutorial follows from [this thread](https://lists.sel4.systems/hyperkitty/list/devel@sel4.systems/thread/XOD6DXC33VRJWEATGIOP4YSGK37UKZYV/) and  [this thread](https://lists.sel4.systems/hyperkitty/list/devel@sel4.systems/thread/NOTNLAC7NS2VWZPBEA2M6CETSR5OOREV/?sort=date) on the devel mailing list.