### PR TITLE
camkes-vm-linux: pick up proper kernel config

### DIFF
--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -421,7 +421,7 @@ GetDefaultLinuxMinor(linux_minor)
 GetDefaultLinuxMd5(linux_md5)
 # Download and Configure our Linux sources
 DownloadLinux(${linux_major} ${linux_minor} ${linux_md5} vm_linux_extract_dir download_vm_linux)
-set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/32/config")
+set(linux_config "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/32/config.backup-singlecore")
 set(linux_symvers "${CAMKES_VM_LINUX_DIR}/linux_configs/${linux_major}.${linux_minor}/32/Module.symvers")
 ConfigureLinux(${vm_linux_extract_dir} ${linux_config} ${linux_symvers} configure_vm_linux
     DEPENDS download_vm_linux

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -512,7 +512,7 @@ In the function `main_continued` register \`poke_handler\`:
 vm_reg_new_vmcall_handler(&vm, poke_handler, 4); // <--- added
 
 /* Now go run the event loop */
-vmm_run(&vm);
+vm_run(&vm);
 ```
 
 Rebuild the project and try out the hypercall + module:


### PR DESCRIPTION
"poke" module should be build with correct Linux configuration to
match the pre-built kernel version. (Tutorial issue #80)

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>