### PR TITLE
Clarify hello-world tutorial

### DIFF
--- a/tutorials/hello-world/hello-world.md
+++ b/tutorials/hello-world/hello-world.md
@@ -57,6 +57,11 @@ Hello, World!
 /*- endfilter --*/
 ```
 
+After that output, there should be a capability violation and a stack dump,
+because the program hasn't properly cleaned up after itself yet. (This will come in later examples)
+
+`Ctrl-A, X` will terminate QEMU.
+
 ## Looking at the sources
 
 In your tutorial directory, you will find the following files:
@@ -178,8 +183,3 @@ Second hello
 /*- endfilter -*/
 ```
 /*- endfilter -*/
-
-After that output, there should be a capability violation and a stack dump,
-because the program hasn't properly cleaned up after itself yet. (This will come in later examples)
-
-`Ctrl-A, X` will terminate QEMU.


### PR DESCRIPTION
Upon running `./simulate`, there is a cap fault after printing, which is somewhat unexpected. There is text explaining that this is to be expected, but it is much later than where the reader would expect.