### PR TITLE
[WIP] Make generated CMake project independent from the project generator

### DIFF
--- a/Findsel4-tutorials.cmake
+++ b/Findsel4-tutorials.cmake
@@ -58,4 +58,4 @@ macro(sel4_tutorials_setup_capdl_tutorial_environment)
 endmacro()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(camkes-tool DEFAULT_MSG SEL4_TUTORIALS_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(sel4-tutorials DEFAULT_MSG SEL4_TUTORIALS_DIR)

--- a/settings.cmake
+++ b/settings.cmake
@@ -20,21 +20,17 @@ set(POLLY_DIR ${project_dir}/tools/polly CACHE INTERNAL "")
 
 include(application_settings)
 
-# Deal with the top level target-triplet variables.
-if(NOT TUT_BOARD)
-    message(
-        FATAL_ERROR
-            "Please select a board to compile for. Choose either pc or zynq7000\n\t`-DTUT_BOARD=<PREFERENCE>`"
-    )
-endif()
+set(TUT_BOARD "pc" CACHE STRING "Target machine to build the project for")
+
 
 # Set arch and board specific kernel parameters here.
 if(${TUT_BOARD} STREQUAL "pc")
     set(KernelArch "x86" CACHE STRING "" FORCE)
     set(KernelPlatform "pc99" CACHE STRING "" FORCE)
-    if(${TUT_ARCH} STREQUAL "ia32")
+    set(TUT_ARCH "x86_64" CACHE STRING "")
+    if("${TUT_ARCH}" STREQUAL "ia32")
         set(KernelSel4Arch "ia32" CACHE STRING "" FORCE)
-    elseif(${TUT_ARCH} STREQUAL "x86_64")
+    elseif("${TUT_ARCH}" STREQUAL "x86_64")
         set(KernelSel4Arch "x86_64" CACHE STRING "" FORCE)
     else()
         message(FATAL_ERROR "Unsupported PC architecture ${TUT_ARCH}")
@@ -58,7 +54,7 @@ elseif(${TUT_BOARD} STREQUAL "zynq7000")
     set(KernelPlatform "zynq7000" CACHE STRING "" FORCE)
     ApplyData61ElfLoaderSettings(${KernelPlatform} ${KernelSel4Arch})
 else()
-    message(FATAL_ERROR "Unsupported board ${TUT_BOARD}.")
+    message(FATAL_ERROR "Unsupported board ${TUT_BOARD}. Choose either pc or zynq7000 with -DTUT_BOARD=<PREFERENCE> or in CMakeCache.txt.`")
 endif()
 
 include(${project_dir}/kernel/configs/seL4Config.cmake)

--- a/settings.cmake
+++ b/settings.cmake
@@ -20,8 +20,11 @@ set(POLLY_DIR ${project_dir}/tools/polly CACHE INTERNAL "")
 
 include(application_settings)
 
-set(TUT_BOARD "pc" CACHE STRING "Target machine to build the project for")
-
+set(TUT_BOARD "" CACHE STRING "Target machine to build the project for")
+if(TUT_BOARD STREQUAL "")
+    message("No board selected (-DTUT_BOARD=[pc|zynq7000]), defaulting to 'pc'")
+    set(TUT_BOARD "pc")
+endif()
 
 # Set arch and board specific kernel parameters here.
 if(${TUT_BOARD} STREQUAL "pc")


### PR DESCRIPTION
Hope to close #88.

- [ ] set SEL4_TUTORIALS_DIR in top level when project is generated
- [ ] auto get TUTORIAL_DIR
- [ ] remove refresh madness (good for developers of tutorials, but should be turned off otherwise)