### PR TITLE
github: code namespace needed by deploy action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     name: Deploy manifest
     if: ${{ github.repository_owner == 'seL4' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, code]
     steps:
     - name: Deploy
       uses: seL4/ci-actions/manifest-deploy@master


### PR DESCRIPTION
The reference `needs.code.outputs.xml` needs the `code` namespace to exist, so we need to include `code` even though `test` already depends on `code`.

Without this, the manifest deployment used the current state of the requested branches, not the state that was tested, so it was possible to run into race conditions.

I've checked the deployment scripts in the other repos, this here was the only one that was missing the namespace.