### PR TITLE
tools: update to sh version 2

### DIFF
--- a/common.py
+++ b/common.py
@@ -66,7 +66,7 @@ def _init_build_directory(config, initialised, directory, tute_directory, output
         tute_dir = "-DTUTORIAL_DIR=" + os.path.basename(tute_directory)
         args = ['-G', 'Ninja'] + config_dict[config] + [tute_dir] + \
             ["-C", "../projects/sel4-tutorials/settings.cmake"]
-    return sh.cmake(args + [tute_directory], _cwd=directory, _out=output, _err=output)
+    return sh.cmake(args + [tute_directory], _cwd=directory, _out=output, _err=output, _return_cmd=True)
 
 
 def _init_tute_directory(config, tut, solution, task, directory, output=None):

--- a/test.py
+++ b/test.py
@@ -47,10 +47,10 @@ def run_single_test_iteration(build_dir, solution, logfile):
 
     check = sh.Command(os.path.join(build_dir, "check"))
     if solution:
-        result = check(_out=logfile, _cwd=build_dir)
+        result = check(_out=logfile, _cwd=build_dir, _return_cmd=True)
     else:
         # We check the start state if not solution
-        result = check("--start", _out=logfile, _cwd=build_dir)
+        result = check("--start", _out=logfile, _cwd=build_dir, _return_cmd=True)
     for proc in psutil.process_iter():
         if "qemu" in proc.name():
             proc.kill()


### PR DESCRIPTION
There was a change to the interface in sh version 2 where [the output is a true string][1], instead of a special object with `return_value` field etc. There is an opt-in available to the old behaviour by passing the keyword argument `_return_cmd=True`--which is what I'm doing here.

That said, with this change (presumably) the older sh version 1 would no longer work due to the new keyword argument... on a note related to that, the FAQ mentions sh being [designed for ease of embedding][2] (essentially, paraphrasing), so it might be worth considering just vendoring one specific version.

I tested the `./init --tut hello-world` with these changes applied, which works (I'm still working on the tutorials/learning the ropes wrt seL4).

[1]: https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
[2]: https://sh.readthedocs.io/en/latest/sections/faq.html#why-is-sh-just-a-single-file