### PR TITLE
tools/context: use yaml instead of pyaml

### DIFF
--- a/tools/context.py
+++ b/tools/context.py
@@ -10,7 +10,7 @@ import inspect
 import os
 import stat
 from pickle import dumps
-import pyaml
+import yaml
 from jinja2 import pass_context
 
 from . import macros
@@ -390,7 +390,7 @@ class TutorialFunctions:
 
             data = {"cap_symbols": stash.cap_symbols, "region_symbols": stash.region_symbols}
 
-            manifest_file.write(pyaml.dump(data))
+            manifest_file.write(yaml.dump(data))
             allocator_file.write(dumps(stash.allocator_state))
         return ""
 


### PR DESCRIPTION
According to the sel4-deps 0.4.0 [commit message](https://github.com/seL4/seL4/commit/2b5c8d3f8481d0f685e1706b4b17a80b38d2d893) from 2019 (!), we don't want Pretty Yaml (`pyaml`), but just `yaml` instead. For here, this should be true.