### PR TITLE
Handle different 'sh' versions for the init tool

### DIFF
--- a/common.py
+++ b/common.py
@@ -66,7 +66,14 @@ def _init_build_directory(config, initialised, directory, tute_directory, output
         tute_dir = "-DTUTORIAL_DIR=" + os.path.basename(tute_directory)
         args = ['-G', 'Ninja'] + config_dict[config] + [tute_dir] + \
             ["-C", "../projects/sel4-tutorials/settings.cmake"]
-    return sh.cmake(args + [tute_directory], _cwd=directory, _out=output, _err=output)
+    result = None
+    if sh.__version__.startswith("1"):
+        result = sh.cmake(args + [tute_directory], _cwd=directory, _out=output,
+                          _err=output)
+    else:
+        result = sh.cmake(args + [tute_directory], _cwd=directory, _out=output,
+                          _err=output, _return_cmd=True)
+    return result
 
 
 def _init_tute_directory(config, tut, solution, task, directory, output=None):

--- a/test.py
+++ b/test.py
@@ -40,17 +40,28 @@ def print_pexpect_failure(failure):
 
 def run_single_test_iteration(build_dir, solution, logfile):
     # Build
-    result = sh.ninja(_out=logfile, _cwd=build_dir)
+    result = None
+    if sh.__version__.startswith("1"):
+        result = sh.ninja(_out=logfile, _cwd=build_dir)
+    else:
+        result = sh.ninja(_out=logfile, _cwd=build_dir, _return_cmd=True)
     if result.exit_code != 0:
         logging.error("Failed to build. Not deleting build directory %s" % build_dir)
         sys.exit(1)
 
     check = sh.Command(os.path.join(build_dir, "check"))
     if solution:
-        result = check(_out=logfile, _cwd=build_dir)
+        if sh.__version__.startswith("1"):
+            result = check(_out=logfile, _cwd=build_dir)
+        else:
+            result = check(_out=logfile, _cwd=build_dir, _return_cmd=True)
     else:
         # We check the start state if not solution
-        result = check("--start", _out=logfile, _cwd=build_dir)
+        if sh.__version__.startswith("1"):
+            result = check("--start", _out=logfile, _cwd=build_dir)
+        else:
+            result = check("--start", _out=logfile, _cwd=build_dir,
+                           _return_cmd=True)
     for proc in psutil.process_iter():
         if "qemu" in proc.name():
             proc.kill()


### PR DESCRIPTION
The `./init` tool fails to exit successfully after initializing the build directory (for all tutorials). The tool runs correctly (e.g., CMake is called, build directories are created), but before exiting, it throws an `AttributeError` exception.

 Below is the output of the command `../init --tut interrupts`.

```sh
-- Build files have been written to: /home/debian/Desktop/sel4-tutorials-manifest/interrupts_build
Traceback (most recent call last):
  File "/home/debian/Desktop/sel4-tutorials-manifest/interrupts/../init", line 91, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/debian/Desktop/sel4-tutorials-manifest/interrupts/../init", line 81, in main
    if result.exit_code != 0:
       ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'exit_code'
debian@debian:~/Desktop/sel4-tutorials-manifest/interrupts$ 
```

I have encountered this error on two different machines /w different operating systems.
* Debian 12, Python 3.11.2 and sel4-deps 0.5.0
* Ubuntu 22.04, Python 3.10.12 and sel4-deps 0.5.0

It is caused by the **sh** Python package. The return value of an executed `sh` command is changed from `RunningCommand` to `string` for versions 2.x and newer. But the `./init` tool expects the return value to be `RunningCommand`. This naturally causes an `AttributeError`.

The maintainers of the **sh** made a [MIGRATION guide](https://github.com/amoffat/sh/blob/develop/MIGRATION.md) that mentions this issue. According to them the `_return_cmd=True` argument should be used to restore the old behavior. 

Pull request #105 fixes the error by following the suggestion, but it directly modifies the calling functions, potentially causing compatibility issues with **sh** version 1.x. Also the **sel4-deps** Python package doesn’t specify the required **sh** version, which may cause further compatibility issues.

This pull request aims to target both **sh** version 1.* and 2.*. It is a rather simple if-else case that checks for the right **sh** version.

Below is a snippet on how it works:

```python
if sh.__version__.startswith("1"):
        sh.cmake(args + [tute_directory], _cwd=directory, _out=output, _err=output)
else:
        sh.cmake(args + [tute_directory], _cwd=directory, _out=output, _err=output, _return_cmd=True)
```

I have tested this change on two different machines specified above for all tutorials. 

_NOTE: Another solution could be to use the built-in `subprocess` module. But that would require a design change to the tool itself. I might try to refactor the tool to reduce its reliance on external modules >.<_ 
