### PR TITLE
Replace (sel4-)?tutorials-manifest with tutorials

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -1,6 +1,0 @@
-# Copyright 2018, Data61, CSIRO (ABN 41 687 119 230)
-# SPDX-License-Identifier: BSD-2-Clause
-
-docs
-*.pyc
-.reuse/dep5

--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -1,0 +1,7 @@
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+urls:
+  # link works, but checker gets 403, because only humans are allowed to check
+  - dl.acm.org/citation.cfm.id=917665

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -38,7 +38,7 @@ in applications loaded by the capDL loader.
 <br>
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 <br>
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Initialising

--- a/tutorials/fault-handlers/fault-handlers.md
+++ b/tutorials/fault-handlers/fault-handlers.md
@@ -56,7 +56,7 @@ in applications loaded by the capDL loader.
 <br>
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 <br>
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Background: What is a fault, and what is a fault handler?

--- a/tutorials/hello-camkes-2/hello-camkes-2.md
+++ b/tutorials/hello-camkes-2/hello-camkes-2.md
@@ -37,7 +37,7 @@ in applications loaded by the capDL loader.
 <br>
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 <br>
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Initialising

--- a/tutorials/hello-camkes-timer/hello-camkes-timer.md
+++ b/tutorials/hello-camkes-timer/hello-camkes-timer.md
@@ -48,7 +48,7 @@ in applications loaded by the capDL loader.
 <br>
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 <br>
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Initialising

--- a/tutorials/hello-world/hello-world.md
+++ b/tutorials/hello-world/hello-world.md
@@ -51,7 +51,7 @@ Initialise the tutorial in Terminal B, which is running the container.
 
 /*? macros.tutorial_init("hello-world") ?*/
 
-This step creates two new directories in `sel4-tutorials-manifest`, namely `hello-world` and `hello-world_build`
+This step creates two new directories in `tutorials/`, namely `hello-world` and `hello-world_build`
 
 <details markdown='1'>
 
@@ -70,7 +70,7 @@ This will generate another `hello-world` directory and `hello-world_build` direc
 ### Build the program
 
 ```
-cd sel4-tutorials-manifest/hello-world_build
+cd tutorials/hello-world_build
 ```
 
 Next, build the program in Terminal B using ninja
@@ -111,7 +111,7 @@ because the program hasn't properly cleaned up after itself yet. (This will come
 To look at the sources, open a new terminal, Terminal A:
 
 ```
-cd sel4-tutorials-manifest/hello-world
+cd tutorials/hello-world
 ls
 ```
 
@@ -161,7 +161,7 @@ target_link_libraries(hello-world
     muslc utils sel4tutorials
     sel4muslcsys sel4platsupport sel4utils sel4debug)
 
-# Tell the build system that this application is the root task. 
+# Tell the build system that this application is the root task.
 include(rootserver)
 DeclareRootserver(hello-world)
 /*- endset -*/
@@ -170,8 +170,8 @@ DeclareRootserver(hello-world)
 
 ### `main.c`
 
-The main C is a very typical C file. For a basic root server application, the only requirement is that 
-a `main` function is provided. 
+The main C is a very typical C file. For a basic root server application, the only requirement is that
+a `main` function is provided.
 
 ```c
 #include <stdio.h>

--- a/tutorials/interrupts/interrupts.md
+++ b/tutorials/interrupts/interrupts.md
@@ -50,7 +50,7 @@ in applications loaded by the capDL loader.
 <br>
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 <br>
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Background

--- a/tutorials/ipc/ipc.md
+++ b/tutorials/ipc/ipc.md
@@ -51,7 +51,7 @@ in applications loaded by the capDL loader.
 
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Background

--- a/tutorials/notifications/notifications.md
+++ b/tutorials/notifications/notifications.md
@@ -53,7 +53,7 @@ in applications loaded by the capDL loader.
 
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 </details>
 
 ## Background

--- a/tutorials/threads/threads.md
+++ b/tutorials/threads/threads.md
@@ -42,7 +42,7 @@ in applications loaded by the capDL loader.
 
 More information about CapDL projects can be found [here](https://docs.sel4.systems/CapDL.html).
 
-For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the tutorials-manifest directory.
+For this tutorial clone the [CapDL repo](https://github.com/sel4/capdl). This can be added in a directory that is adjacent to the main `tutorials` directory.
 
 ## Initialising
 


### PR DESCRIPTION
The previous usage was inconsistent, sometimes with and sometimes without "sel4-", and also somewhat misleading. The directory does not (only) contain the manifest, but mainly the content of the manifest. The manifest itself is in a hidden directory inside.